### PR TITLE
fixed scope of toString() call

### DIFF
--- a/src/helpers/patternformatter.cpp
+++ b/src/helpers/patternformatter.cpp
@@ -701,7 +701,7 @@ QDebug BasicPatternConverter::debug(QDebug &rDebug) const
 
 QString DatePatternConverter::convert(const LoggingEvent &rLoggingEvent) const
 {
-    return DateTime::fromMSecsSinceEpoch(rLoggingEvent.timeStamp()).toString(mFormat);
+    return static_cast<const DateTime &>(DateTime::fromMSecsSinceEpoch(rLoggingEvent.timeStamp())).toString(mFormat);
 }
 
 


### PR DESCRIPTION
`DateTime::toString()` method should be called instead of `QDateTime::toString()`.
This would fix 5 of `Log4QtTest::PatternFormatter` currently failing tests.