### PR TITLE
Make it compile

### DIFF
--- a/src/log4qt/databaseappender.cpp
+++ b/src/log4qt/databaseappender.cpp
@@ -123,7 +123,7 @@ bool DatabaseAppender::requiresLayout() const
 
 void DatabaseAppender::append(const LoggingEvent &rEvent)
 {
-    DatabaseLayout *databaseLayout = qobject_cast<DatabaseLayout *>(layout());
+    DatabaseLayout *databaseLayout = qobject_cast<DatabaseLayout *>(layout().data());
 
     if (databaseLayout)
     {

--- a/src/log4qt/logmanager.cpp
+++ b/src/log4qt/logmanager.cpp
@@ -40,7 +40,7 @@
 #include "ttcclayout.h"
 #include "varia/denyallfilter.h"
 #include "varia/levelrangefilter.h"
-#include "configuratorhelper.h"
+#include "helpers/configuratorhelper.h"
 
 #include <QCoreApplication>
 #include <QFile>

--- a/tests/binaryloggertest/logging.cpp
+++ b/tests/binaryloggertest/logging.cpp
@@ -46,7 +46,7 @@ QString Logging::createDumpString(const QByteArray &data, const bool withCaption
         line.append(' ');
 
         if ( byte >= fromChar && byte <= toChar )
-            details.append(QChar::fromLatin1(byte));
+            details.append(static_cast<char>(byte));
         else
             details.append('.');
 
@@ -59,7 +59,7 @@ QString Logging::createDumpString(const QByteArray &data, const bool withCaption
             line.clear();
 
             line.append(intention);
-            line.append(QString::fromLatin1("%0  ").arg(i, 8, 16, QLatin1Char('0')));
+            line.append(QStringLiteral("%0  ").arg(i, 8, 16, QLatin1Char('0')).toLatin1());
 
             details.clear();
             details.append(dist);


### PR DESCRIPTION
I needed those small changes to be able to compile it on my system. Looks like databaseappender.cpp is not compiled at all - at lteast the qmake output tells me that those files are skipped although I have Qt5::Sql installed..
The other come from different defines (e.g. avoid implicit converting from QString to QByteArray)