### PR TITLE
Remove ununsed includes in public headers

### DIFF
--- a/src/log4qt/asyncappender.h
+++ b/src/log4qt/asyncappender.h
@@ -28,9 +28,6 @@
 #include "appenderskeleton.h"
 #include "helpers/appenderattachable.h"
 
-#include <QQueue>
-#include <QMutex>
-
 namespace Log4Qt
 {
 

--- a/src/log4qt/binarywriterappender.cpp
+++ b/src/log4qt/binarywriterappender.cpp
@@ -1,6 +1,7 @@
 #include "binarywriterappender.h"
 #include "binaryloggingevent.h"
 #include "binarylayout.h"
+#include <QDataStream>
 
 namespace Log4Qt
 {

--- a/src/log4qt/binarywriterappender.h
+++ b/src/log4qt/binarywriterappender.h
@@ -3,8 +3,7 @@
 
 #include "appenderskeleton.h"
 
-#include <QDataStream>
-
+class QDataStream;
 namespace Log4Qt
 {
 

--- a/src/log4qt/colorconsoleappender.h
+++ b/src/log4qt/colorconsoleappender.h
@@ -27,10 +27,6 @@
 
 #include "consoleappender.h"
 
-#include <QHash>
-#include <QPair>
-#include <QRegExp>
-
 // if we are in WIN*
 #if defined(__WIN32__) || defined(WIN) || defined(WIN32) || defined(Q_OS_WIN32)
 #define WIN32_LEAN_AND_MEAN

--- a/src/log4qt/consoleappender.h
+++ b/src/log4qt/consoleappender.h
@@ -27,7 +27,6 @@
 
 #include "writerappender.h"
 
-class QFile;
 class QTextStream;
 
 namespace Log4Qt

--- a/src/log4qt/dailyfileappender.h
+++ b/src/log4qt/dailyfileappender.h
@@ -27,8 +27,8 @@
 
 #include "fileappender.h"
 
-#include <QDateTime>
 #include <QString>
+#include <QDate>
 
 namespace Log4Qt
 {

--- a/src/log4qt/helpers/binaryclasslogger.h
+++ b/src/log4qt/helpers/binaryclasslogger.h
@@ -3,9 +3,9 @@
 
 #include "log4qtshared.h"
 
-#include <QObject>
 #include <QAtomicPointer>
 
+class QObject;
 namespace Log4Qt
 {
 

--- a/src/log4qt/helpers/classlogger.h
+++ b/src/log4qt/helpers/classlogger.h
@@ -32,8 +32,8 @@
 
 #include "log4qtshared.h"
 
-#include <QObject>
 #include <QAtomicPointer>
+class QObject;
 
 namespace Log4Qt
 {

--- a/src/log4qt/helpers/dispatcher.h
+++ b/src/log4qt/helpers/dispatcher.h
@@ -25,7 +25,6 @@
 #ifndef LOG4QTDISPATCHER_H
 #define LOG4QTDISPATCHER_H
 
-#include <QList>
 #include <QObject>
 
 namespace Log4Qt

--- a/src/log4qt/logger.h
+++ b/src/log4qt/logger.h
@@ -35,8 +35,6 @@
 
 #include <QObject>
 
-#include <QList>
-#include <QReadWriteLock>
 #include "helpers/logerror.h"
 #include "helpers/classlogger.h"
 #include "helpers/appenderattachable.h"

--- a/src/log4qt/loggingevent.h
+++ b/src/log4qt/loggingevent.h
@@ -27,9 +27,7 @@
 
 #include "level.h"
 
-#include <QDateTime>
 #include <QHash>
-#include <QMetaType>
 #include <QStringList>
 #include <QEvent>
 

--- a/src/log4qt/logmanager.h
+++ b/src/log4qt/logmanager.h
@@ -28,8 +28,6 @@
 #include "level.h"
 #include "logger.h"
 
-#include <QObject>
-#include <QHash>
 #include <QList>
 #include <QMutex>
 #include <QString>

--- a/src/log4qt/logstream.h
+++ b/src/log4qt/logstream.h
@@ -28,7 +28,6 @@
 #include "level.h"
 
 #include <QTextStream>
-#include <QTextStream>
 #include <QString>
 #include <QSharedPointer>
 #include <QPointer>

--- a/src/log4qt/mainthreadappender.h
+++ b/src/log4qt/mainthreadappender.h
@@ -28,9 +28,6 @@
 #include "appenderskeleton.h"
 #include "helpers/appenderattachable.h"
 
-#include <QQueue>
-#include <QMutex>
-
 namespace Log4Qt
 {
 

--- a/src/log4qt/varia/listappender.h
+++ b/src/log4qt/varia/listappender.h
@@ -29,7 +29,6 @@
 #include "loggingevent.h"
 
 #include <QList>
-#include <QMutex>
 
 namespace Log4Qt
 {


### PR DESCRIPTION
There are a lot of unneeded includes in the public headers. Don't know if they should be removed in 1.0.0 or in a later version since it is potentially a sic...