### PR TITLE
Adjust include statements in subdirectories

### DIFF
--- a/examples/basic/basic.pro
+++ b/examples/basic/basic.pro
@@ -21,5 +21,5 @@ HEADERS  += \
     loggerstatic.h
 
 DEPENDPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
-INCLUDEPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
+INCLUDEPATH += ../../src/ ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
 

--- a/examples/propertyconfigurator/propertyconfigurator.pro
+++ b/examples/propertyconfigurator/propertyconfigurator.pro
@@ -21,7 +21,7 @@ HEADERS  += \
     loggerstatic.h
 
 DEPENDPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
-INCLUDEPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
+INCLUDEPATH += ../../src/ ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
 
 DISTFILES += \
     propertyconfigurator.exe.log4qt.properties

--- a/src/log4qt/log4qt.pro
+++ b/src/log4qt/log4qt.pro
@@ -13,6 +13,7 @@ contains(DEFINES, LOG4QT_STATIC) {
 
 TEMPLATE = lib
 TARGET = log4qt
+QT -= gui
 
 LOG4QT_VERSION_MAJOR = 1
 LOG4QT_VERSION_MINOR = 4
@@ -23,7 +24,9 @@ DEFINES += LOG4QT_VERSION_STR=\"$${LOG4QT_VERSION}\"
 DEFINES += LOG4QT_VERSION=$${LOG4QT_VERSION}
 
 DEPENDPATH += . helpers spi varia
-INCLUDEPATH += . helpers spi varia
+# .. is needed for msvc since it is treating '.' as the directory of the current file
+# and not the directory where the compiled source is found
+INCLUDEPATH += .. . helpers spi varia
 
 DESTDIR = ../../bin
 DEFINES += NOMINMAX QT_DEPRECATED_WARNINGS QT_NO_CAST_FROM_BYTEARRAY QT_USE_QSTRINGBUILDER

--- a/src/log4qt/spi/filter.h
+++ b/src/log4qt/spi/filter.h
@@ -25,8 +25,8 @@
 #ifndef LOG4QT_FILTER_H
 #define LOG4QT_FILTER_H
 
-#include "log4qt.h"
-#include "log4qtsharedptr.h"
+#include <log4qt/log4qt.h>
+#include <log4qt/log4qtsharedptr.h>
 
 #include <QObject>
 

--- a/src/log4qt/varia/binaryeventfilter.h
+++ b/src/log4qt/varia/binaryeventfilter.h
@@ -1,7 +1,7 @@
 #ifndef LOG4QT_BINARYEVENTFILTER_H
 #define LOG4QT_BINARYEVENTFILTER_H
 
-#include "spi/filter.h"
+#include <log4qt/spi/filter.h>
 
 namespace Log4Qt
 {

--- a/src/log4qt/varia/debugappender.h
+++ b/src/log4qt/varia/debugappender.h
@@ -25,7 +25,7 @@
 #ifndef LOG4QT_DEBUGAPPENDER_H
 #define LOG4QT_DEBUGAPPENDER_H
 
-#include "appenderskeleton.h"
+#include <log4qt/appenderskeleton.h>
 
 namespace Log4Qt
 {

--- a/src/log4qt/varia/denyallfilter.h
+++ b/src/log4qt/varia/denyallfilter.h
@@ -30,7 +30,7 @@
 #ifndef LOG4QT_DENYALLFILTER_H
 #define LOG4QT_DENYALLFILTER_H
 
-#include "spi/filter.h"
+#include <log4qt/spi/filter.h>
 
 namespace Log4Qt
 {

--- a/src/log4qt/varia/levelmatchfilter.h
+++ b/src/log4qt/varia/levelmatchfilter.h
@@ -25,9 +25,8 @@
 #ifndef LOG4QT_LEVELMATCHFILTER_H
 #define LOG4QT_LEVELMATCHFILTER_H
 
-#include "spi/filter.h"
-
-#include "level.h"
+#include <log4qt/spi/filter.h>
+#include <log4qt/level.h>
 
 namespace Log4Qt
 {

--- a/src/log4qt/varia/levelrangefilter.h
+++ b/src/log4qt/varia/levelrangefilter.h
@@ -25,9 +25,8 @@
 #ifndef LOG4QT_LEVELRANGEFILTER_H
 #define LOG4QT_LEVELRANGEFILTER_H
 
-#include "spi/filter.h"
-
-#include "level.h"
+#include <log4qt/spi/filter.h>
+#include <log4qt/level.h>
 
 namespace Log4Qt
 {

--- a/src/log4qt/varia/listappender.h
+++ b/src/log4qt/varia/listappender.h
@@ -25,8 +25,8 @@
 #ifndef LOG4QT_LISTAPPENDER_H
 #define LOG4QT_LISTAPPENDER_H
 
-#include "appenderskeleton.h"
-#include "loggingevent.h"
+#include <log4qt/appenderskeleton.h>
+#include <log4qt/loggingevent.h>
 
 #include <QList>
 

--- a/src/log4qt/varia/nullappender.h
+++ b/src/log4qt/varia/nullappender.h
@@ -25,7 +25,7 @@
 #ifndef LOG4QT_NULLAPPENDER_H
 #define LOG4QT_NULLAPPENDER_H
 
-#include "appenderskeleton.h"
+#include <log4qt/appenderskeleton.h>
 
 namespace Log4Qt
 {

--- a/src/log4qt/varia/stringmatchfilter.h
+++ b/src/log4qt/varia/stringmatchfilter.h
@@ -25,7 +25,7 @@
 #ifndef LOG4QT_STRINGMATCHFILTER_H
 #define LOG4QT_STRINGMATCHFILTER_H
 
-#include "spi/filter.h"
+#include <log4qt/spi/filter.h>
 
 namespace Log4Qt
 {

--- a/tests/binaryloggertest/binaryloggertest.pro
+++ b/tests/binaryloggertest/binaryloggertest.pro
@@ -22,4 +22,4 @@ LIBS += -L../../bin/ \
          -llog4qt
 
 DEPENDPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
-INCLUDEPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
+INCLUDEPATH += ../../src/ ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia

--- a/tests/log4qttest/log4qttest.pro
+++ b/tests/log4qttest/log4qttest.pro
@@ -10,7 +10,7 @@ QT -= gui
 
 
 DEPENDPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
-INCLUDEPATH += ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
+INCLUDEPATH += ../../src/ ../../src/log4qt ../../src/log4qt/helpers ../../src/log4qt/spi ../../src/log4qt/varia
 
 HEADERS += log4qttest.h
 SOURCES += log4qttest.cpp


### PR DESCRIPTION
The include statements in the subdirectories are wrong when the headers are installed since then the path /bar/include/log4qt is not in the compiler include path (and there is no need for it) - therefore use #include <log4qt/foo.h> which works during building and usage of the library.