### PR TITLE
Adjust include statements in subdirectories (part2)

### DIFF
--- a/src/log4qt/helpers/appenderattachable.h
+++ b/src/log4qt/helpers/appenderattachable.h
@@ -25,9 +25,8 @@
 #ifndef LOG4QT_APPENDERATTACHABLE_H
 #define LOG4QT_APPENDERATTACHABLE_H
 
-#include "../log4qt.h"
-
-#include "appender.h"
+#include <log4qt/log4qt.h>
+#include <log4qt/appender.h>
 
 #include <QList>
 #include <QReadWriteLock>

--- a/src/log4qt/helpers/binaryclasslogger.h
+++ b/src/log4qt/helpers/binaryclasslogger.h
@@ -1,7 +1,7 @@
 #ifndef LOG4QT_BINARYCLASSLOGGER_H
 #define LOG4QT_BINARYCLASSLOGGER_H
 
-#include "log4qtshared.h"
+#include <log4qt/log4qtshared.h>
 
 #include <QAtomicPointer>
 

--- a/src/log4qt/helpers/classlogger.h
+++ b/src/log4qt/helpers/classlogger.h
@@ -30,7 +30,7 @@
 #ifndef LOG4QT_CLASSLOGGER_H
 #define LOG4QT_CLASSLOGGER_H
 
-#include "log4qtshared.h"
+#include <log4qt/log4qtshared.h>
 
 #include <QAtomicPointer>
 class QObject;

--- a/src/log4qt/helpers/configuratorhelper.h
+++ b/src/log4qt/helpers/configuratorhelper.h
@@ -25,8 +25,8 @@
 #ifndef LOG4QT_HELPERS_CONFIGURATORHELPER_H
 #define LOG4QT_HELPERS_CONFIGURATORHELPER_H
 
-#include "log4qtshared.h"
-#include "loggingevent.h"
+#include <log4qt/log4qtshared.h>
+#include <log4qt/loggingevent.h>
 
 #include <QObject>
 #include <QList>

--- a/src/log4qt/helpers/datetime.h
+++ b/src/log4qt/helpers/datetime.h
@@ -29,7 +29,7 @@
 #ifndef LOG4QT_HELPERS_DATETIME_H
 #define LOG4QT_HELPERS_DATETIME_H
 
-#include "log4qtshared.h"
+#include <log4qt/log4qtshared.h>
 
 #include <QDateTime>
 

--- a/src/log4qt/helpers/factory.h
+++ b/src/log4qt/helpers/factory.h
@@ -25,7 +25,7 @@
 #ifndef LOG4QT_HELPERS_FACTORY_H
 #define LOG4QT_HELPERS_FACTORY_H
 
-#include "log4qtshared.h"
+#include <log4qt/log4qtshared.h>
 
 #include <QHash>
 #include <QMutex>

--- a/src/log4qt/helpers/initialisationhelper.h
+++ b/src/log4qt/helpers/initialisationhelper.h
@@ -32,7 +32,8 @@
 
 #ifndef LOG4QT_HELPERS_INITIALISATIONHELPER_H
 #define LOG4QT_HELPERS_INITIALISATIONHELPER_H
-#include "log4qtshared.h"
+
+#include <log4qt/log4qtshared.h>
 
 #include <QHash>
 #include <QString>

--- a/src/log4qt/helpers/logerror.h
+++ b/src/log4qt/helpers/logerror.h
@@ -25,7 +25,7 @@
 #ifndef LOG4QT_LOGERROR_H
 #define LOG4QT_LOGERROR_H
 
-#include "log4qtshared.h"
+#include <log4qt/log4qtshared.h>
 
 #include <QString>
 #include <QVariant>

--- a/src/log4qt/helpers/optionconverter.h
+++ b/src/log4qt/helpers/optionconverter.h
@@ -25,8 +25,8 @@
 #ifndef LOG4QT_OPTIONCONVERTER_H
 #define LOG4QT_OPTIONCONVERTER_H
 
-#include "log4qtshared.h"
-#include "level.h"
+#include <log4qt/log4qtshared.h>
+#include <log4qt/level.h>
 
 #include <QString>
 

--- a/src/log4qt/helpers/patternformatter.h
+++ b/src/log4qt/helpers/patternformatter.h
@@ -25,7 +25,7 @@
 #ifndef LOG4QT_PATTERNFORMATTER_H
 #define LOG4QT_PATTERNFORMATTER_H
 
-#include "log4qtshared.h"
+#include <log4qt/log4qtshared.h>
 
 #include <QList>
 #include <QString>

--- a/src/log4qt/helpers/properties.h
+++ b/src/log4qt/helpers/properties.h
@@ -25,7 +25,7 @@
 #ifndef LOG4QT_PROPERTIES_H
 #define LOG4QT_PROPERTIES_H
 
-#include "log4qtshared.h"
+#include <log4qt/log4qtshared.h>
 
 #include <QHash>
 #include <QStringList>


### PR DESCRIPTION
Adjust include statements in subdirectories so that the headers are also found when they are installed, part 2
Sorry for the double pull request - somehow those changes were not merged into the correct branch...