### PR TITLE
add support for 'make install' with qmake

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,14 +59,21 @@ use qmake to build the project
         make
         make install
 
-    WIN*
+    WIN* (mingw)
         qmake
         mingw32-make
         mingw32-make install
 
+    WIN* (msvc)
+        qmake
+        msbuild Log4Qt.sln
+        msbuild /t:INSTALL Log4Qt.sln
+
     For static build call qmake with
     qmake "DEFINES+=LOG4QT_STATIC" or uncommend LOG4QT_STATIC in the build.pri file
     Don't forget to define LOG4QT_STATIC also in your project.
+
+    Logging to a database via databaseappender can be enabled with qmake "QT += sql"
 
 ### include in your project
 Can also be used by adding the log4qt source directly to your Qt project file by adding the following line:

--- a/build.pri
+++ b/build.pri
@@ -1,1 +1,4 @@
-DEFINES += #LOG4QT_STATIC
+# uncomment if you want to build a static log4qt library
+#DEFINES += LOG4QT_STATIC
+# uncomment if you want to log to a database via databaselogger
+# QT += sql

--- a/examples/basic/basic.pro
+++ b/examples/basic/basic.pro
@@ -1,7 +1,8 @@
 include(../examples.pri)
 include(../../build.pri)
 
-QT       += core network
+QT += core network
+QT -= gui
 
 TEMPLATE = app
 DESTDIR = ../../bin

--- a/src/log4qt/log4qt.pri
+++ b/src/log4qt/log4qt.pri
@@ -1,68 +1,71 @@
-HEADERS += $$PWD/appender.h \
+HEADERS_BASE += \
+           $$PWD/appender.h \
            $$PWD/appenderskeleton.h \
+           $$PWD/asyncappender.h \
            $$PWD/basicconfigurator.h \
+           $$PWD/binaryfileappender.h \
+           $$PWD/binarylayout.h \
+           $$PWD/binarylogger.h \
+           $$PWD/binaryloggingevent.h \
+           $$PWD/binarylogstream.h \
+           $$PWD/binarytotextlayout.h \
+           $$PWD/binarywriterappender.h \
            $$PWD/colorconsoleappender.h \
            $$PWD/consoleappender.h \
-           $$PWD/dailyrollingfileappender.h \
-           $$PWD/asyncappender.h \
            $$PWD/dailyfileappender.h \
-           $$PWD/mainthreadappender.h \
+           $$PWD/dailyrollingfileappender.h \
            $$PWD/fileappender.h \
            $$PWD/hierarchy.h \
            $$PWD/layout.h \
            $$PWD/level.h \
            $$PWD/log4qt.h \
            $$PWD/log4qtshared.h \
+           $$PWD/log4qtsharedptr.h \
            $$PWD/logger.h \
            $$PWD/loggerrepository.h \
            $$PWD/loggingevent.h \
            $$PWD/logmanager.h \
+           $$PWD/logstream.h \
+           $$PWD/mainthreadappender.h \
            $$PWD/mdc.h \
            $$PWD/ndc.h \
            $$PWD/patternlayout.h \
            $$PWD/propertyconfigurator.h \
+           $$PWD/qmllogger.h \
+           $$PWD/rollingbinaryfileappender.h \
            $$PWD/rollingfileappender.h \
            $$PWD/signalappender.h \
            $$PWD/simplelayout.h \
            $$PWD/simpletimelayout.h \
-           $$PWD/ttcclayout.h \
-           $$PWD/telnetappender.h \
-           $$PWD/writerappender.h \
            $$PWD/systemlogappender.h \
+           $$PWD/telnetappender.h \
+           $$PWD/ttcclayout.h \
+           $$PWD/writerappender.h \
+           $$PWD/xmllayout.h
+HEADERS_HELPERS += \
+           $$PWD/helpers/appenderattachable.h \
+           $$PWD/helpers/binaryclasslogger.h \
            $$PWD/helpers/classlogger.h \
-           $$PWD//helpers/appenderattachable.h \
            $$PWD/helpers/configuratorhelper.h \
            $$PWD/helpers/datetime.h \
+           $$PWD/helpers/dispatcher.h \
            $$PWD/helpers/factory.h \
            $$PWD/helpers/initialisationhelper.h \
            $$PWD/helpers/logerror.h \
            $$PWD/helpers/optionconverter.h \
            $$PWD/helpers/patternformatter.h \
-           $$PWD/helpers/properties.h \
-           $$PWD/helpers/dispatcher.h \
-           $$PWD/spi/filter.h \
+           $$PWD/helpers/properties.h
+HEADERS_SPI += \
+           $$PWD/spi/filter.h
+HEADERS_VARIA += \
+           $$PWD/varia/binaryeventfilter.h \
            $$PWD/varia/debugappender.h \
            $$PWD/varia/denyallfilter.h \
            $$PWD/varia/levelmatchfilter.h \
            $$PWD/varia/levelrangefilter.h \
            $$PWD/varia/listappender.h \
            $$PWD/varia/nullappender.h \
-           $$PWD/varia/stringmatchfilter.h \
-           $$PWD/logstream.h \
-           $$PWD/binaryloggingevent.h \
-           $$PWD/binarylogger.h \
-           $$PWD/varia/binaryeventfilter.h \
-           $$PWD/binarytotextlayout.h \
-           $$PWD/binarywriterappender.h \
-           $$PWD/binaryfileappender.h \
-           $$PWD/binarylogstream.h \
-           $$PWD/helpers/binaryclasslogger.h \
-           $$PWD/rollingbinaryfileappender.h \
-           $$PWD/binarylayout.h \
-           $$PWD/xmllayout.h \
-    	   $$PWD/qmllogger.h \
-           $$PWD/log4qtsharedptr.h
-
+           $$PWD/varia/stringmatchfilter.h
 SOURCES += $$PWD/appender.cpp \
            $$PWD/appenderskeleton.cpp \
            $$PWD/basicconfigurator.cpp \
@@ -133,7 +136,7 @@ msvc {
 # add databaseappender and -layout if QT contains sql
 contains(QT, sql) {
 message("Including databaseappender and -layout")
-HEADERS += \
+HEADERS_BASE += \
     $$PWD/databaseappender.h \
     $$PWD/databaselayout.h
 
@@ -144,9 +147,13 @@ SOURCES += \
 }
 
 win32 {
-    HEADERS+=$$PWD/wdcappender.h
+    HEADERS_BASE+=$$PWD/wdcappender.h
     SOURCES+=$$PWD/wdcappender.cpp
 }
+HEADERS += $$HEADERS_BASE \
+           $$HEADERS_HELPERS \
+           $$HEADERS_SPI \
+           $$HEADERS_VARIA
 
 !contains(QT, sql) {
 message("Skipping databaseappender and -layout")

--- a/src/log4qt/log4qt.pro
+++ b/src/log4qt/log4qt.pro
@@ -1,7 +1,7 @@
 QT += core xml network
-include(log4qt.pri)
-include(../../g++.pri)
 include(../../build.pri)
+include(../../g++.pri)
+include(log4qt.pri)
 
 CONFIG += c++11 \
           hide_symbols
@@ -30,3 +30,20 @@ INCLUDEPATH += .. .
 DESTDIR = ../../bin
 DEFINES += NOMINMAX QT_DEPRECATED_WARNINGS QT_NO_CAST_FROM_BYTEARRAY QT_USE_QSTRINGBUILDER
 DEFINES += LOG4QT_LIBRARY
+
+target.path = $$INSTALL_PREFIX/lib$$LIB_SUFFIX
+INSTALLS = target
+
+header_base.files = $$HEADERS_BASE
+header_base.path = $$INSTALL_PREFIX/include/log4qt
+INSTALLS += header_base
+header_helpers.files = $$HEADERS_HELPERS
+header_helpers.path = $$INSTALL_PREFIX/include/log4qt/helpers
+INSTALLS += header_helpers
+header_spi.files = $$HEADERS_SPI
+header_spi.path = $$INSTALL_PREFIX/include/log4qt/spi
+INSTALLS += header_spi
+header_varia.files = $$HEADERS_VARIA
+header_varia.path = $$INSTALL_PREFIX/include/log4qt/varia
+INSTALLS += header_varia
+

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -2,7 +2,8 @@ include (../g++.pri)
 include (../build.pri)
 
 CONFIG += c++11 \
-          testcase
+          testcase \
+          no_testcase_installs
 
 mac {
     CONFIG -= app_bundle


### PR DESCRIPTION
make install was broken because on windows it is not common to do this. But on linux, esp. for packaging, this is necessary.
'testcase' automatically creates a install target, therefore I had to add no_testcase_installs.
updated the Readme.md for databaseappender and msvc builds