### PR TITLE
Use QString::midRef()/splitRef() where possible, remove some unused variables

### DIFF
--- a/src/log4qt/helpers/logerror.cpp
+++ b/src/log4qt/helpers/logerror.cpp
@@ -268,8 +268,6 @@ QDataStream &operator>>(QDataStream &rStream,
     quint16 version;
     stream >> version;
     // Version 0 data
-    QString level;
-    QString logger;
     stream >> rLogError.mCode
            >> rLogError.mContext
            >> rLogError.mMessage

--- a/src/log4qt/helpers/optionconverter.cpp
+++ b/src/log4qt/helpers/optionconverter.cpp
@@ -63,12 +63,12 @@ QString OptionConverter::findAndSubst(const Properties &rProperties,
         begin = value.indexOf(begin_subst, i);
         if (begin == -1)
         {
-            result += value.mid(i);
+            result += value.midRef(i);
             i = value.length();
         }
         else
         {
-            result += value.mid(i, begin - i);
+            result += value.midRef(i, begin - i);
             end = value.indexOf(end_subst, i + begin_length);
             if (end == -1)
             {

--- a/src/log4qt/helpers/patternformatter.cpp
+++ b/src/log4qt/helpers/patternformatter.cpp
@@ -283,8 +283,7 @@ PatternFormatter::PatternFormatter(const QString &rPattern) :
 
 PatternFormatter::~PatternFormatter()
 {
-    for (auto p_converter : mPatternConverters)
-        delete p_converter;
+    qDeleteAll(mPatternConverters);
 }
 
 
@@ -569,7 +568,7 @@ void PatternFormatter::parse()
         if (state == ESCAPE_STATE)
             literal += c;
         else
-            literal += mPattern.mid(converter_start);
+            literal += mPattern.midRef(converter_start);
     }
 
     if (!literal.isEmpty())
@@ -626,7 +625,7 @@ void PatternConverter::format(QString &rFormat, const LoggingEvent &rLoggingEven
     QString s = convert(rLoggingEvent);
 
     if (s.length() > mFormattingInfo.mMaxLength)
-        rFormat += s.left(mFormattingInfo.mMaxLength);
+        rFormat += s.leftRef(mFormattingInfo.mMaxLength);
     else if (mFormattingInfo.mLeftAligned)
         rFormat += s.leftJustified(mFormattingInfo.mMinLength, space, false);
     else

--- a/src/log4qt/helpers/properties.cpp
+++ b/src/log4qt/helpers/properties.cpp
@@ -57,7 +57,7 @@ void Properties::load(QIODevice *pDevice)
         line_number++;
 
         if (!line.isEmpty() && line.at(line.length() - 1) == append_char)
-            property += line.left(line.length() - 1);
+            property += line.leftRef(line.length() - 1);
         else
         {
             property += line;

--- a/src/log4qt/logmanager.cpp
+++ b/src/log4qt/logmanager.cpp
@@ -279,7 +279,6 @@ void LogManager::doStartup()
         s.beginGroup(log4qt_group);
         if (s.childGroups().contains(properties_group))
         {
-            const QString group(QLatin1String("Properties"));
             static_logger()->debug("Default initialisation configures from setting '%1/%2'", log4qt_group, properties_group);
             s.beginGroup(properties_group);
             PropertyConfigurator::configure(s);

--- a/src/log4qt/systemlogappender.cpp
+++ b/src/log4qt/systemlogappender.cpp
@@ -5,7 +5,6 @@
 #include "loggingevent.h"
 
 #include <QCoreApplication>
-#include <QVector>
 
 #if defined(Q_OS_WIN32)
 #ifndef UNICODE
@@ -141,7 +140,7 @@ void SystemLogAppender::append(const LoggingEvent &rEvent)
     }
 
     openlog(ident, LOG_PID, LOG_DAEMON);
-    for (const auto &line : message.splitRef('\n', QString::SkipEmptyParts))
+    for (const auto &line : message.split('\n', QString::SkipEmptyParts))
         syslog(st, "%s", line.toLocal8Bit().constData());
     closelog();
 

--- a/src/log4qt/systemlogappender.cpp
+++ b/src/log4qt/systemlogappender.cpp
@@ -5,6 +5,7 @@
 #include "loggingevent.h"
 
 #include <QCoreApplication>
+#include <QVector>
 
 #if defined(Q_OS_WIN32)
 #ifndef UNICODE
@@ -140,7 +141,7 @@ void SystemLogAppender::append(const LoggingEvent &rEvent)
     }
 
     openlog(ident, LOG_PID, LOG_DAEMON);
-    for (const auto &line : message.split('\n', QString::SkipEmptyParts))
+    for (const auto &line : message.splitRef('\n', QString::SkipEmptyParts))
         syslog(st, "%s", line.toLocal8Bit().constData());
     closelog();
 


### PR DESCRIPTION
Avoid some useless QString creations by using QStringRef instead. Qt 5.3 is also supported (see code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/tools/qstring.h?h=5.3 line 395).
Also remove some unused QStrings and use qDeleteAll() for lazyness