### PR TITLE
Fix Patternformatter maxLength behaviour 

### DIFF
--- a/src/log4qt/helpers/patternformatter.cpp
+++ b/src/log4qt/helpers/patternformatter.cpp
@@ -621,11 +621,13 @@ QString FormattingInfo::intToString(int i)
 
 void PatternConverter::format(QString &rFormat, const LoggingEvent &rLoggingEvent) const
 {
-    const QLatin1Char space(' ');
-    QString s = convert(rLoggingEvent);
+    Q_DECL_CONSTEXPR const QLatin1Char space(' ');
+    const QString s = convert(rLoggingEvent);
 
+    // If the data item is longer than the maximum field, then the extra characters
+    // are removed from the beginning of the data item and not from the end.
     if (s.length() > mFormattingInfo.mMaxLength)
-        rFormat += s.leftRef(mFormattingInfo.mMaxLength);
+        rFormat += s.rightRef(mFormattingInfo.mMaxLength);
     else if (mFormattingInfo.mLeftAligned)
         rFormat += s.leftJustified(mFormattingInfo.mMinLength, space, false);
     else

--- a/tests/log4qttest/log4qttest.cpp
+++ b/tests/log4qttest/log4qttest.cpp
@@ -236,7 +236,7 @@ void Log4QtTest::PatternFormatter_data()
                             "threadwithextralongname",
                             relative_timestamp)
             << "%-6r [%15.15t] %-5p %30.30c %x - %m%n"
-            << relative_string + "  [threadwithextra] INFO                Test::TestLog4Qt NDC - This is the message" + eol
+            << relative_string + "  [thextralongname] INFO                Test::TestLog4Qt NDC - This is the message" + eol
             << 0;
     QTest::newRow("TTCC with ISO date")
             << LoggingEvent(test_logger(),


### PR DESCRIPTION
Fix Patternformatter maxLength behaviour to match the log4j documentation: If the data item is longer than the maximum field, then the extra characters are removed *from the beginning* of the data item and not from the end.
See https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html