### PR TITLE
Allow java - loggernames within Hierarchy::createLogger()

### DIFF
--- a/src/log4qt/hierarchy.cpp
+++ b/src/log4qt/hierarchy.cpp
@@ -31,6 +31,7 @@
 
 #include "logger.h"
 #include "binarylogger.h"
+#include "helpers/optionconverter.h"
 
 namespace Log4Qt
 {
@@ -123,7 +124,7 @@ Logger *Hierarchy::createLogger(const QString &orgName)
     static const char binaryIndicator[] = "@@binary@@";
 
 
-    QString rName(orgName);
+    QString rName(OptionConverter::classNameJavaToCpp(orgName));
     bool needBinaryLogger = orgName.contains(binaryIndicator);
 
     if (needBinaryLogger)


### PR DESCRIPTION
Allow java - loggernames in the form 'Foo.bar' within Hierarchy::createLogger(). The notation is also allowed in the property-config - so allowing this here too is just consistent.
This makes transition from log4cxx easier :)