### PR TITLE
Work around a bug in the inotify qfsw implementation (Qt bug 19350)

### DIFF
--- a/src/log4qt/helpers/configuratorhelper.cpp
+++ b/src/log4qt/helpers/configuratorhelper.cpp
@@ -27,6 +27,7 @@
 #include "helpers/initialisationhelper.h"
 
 #include <QFileSystemWatcher>
+#include <QTimer>
 #include <QDebug>
 
 namespace Log4Qt
@@ -53,13 +54,19 @@ LOG4QT_IMPLEMENT_INSTANCE(ConfiguratorHelper)
 
 void ConfiguratorHelper::doConfigurationFileChanged(const QString &rFileName)
 {
-    // work around a bug in the inotify qfsw implementation (Qt bug 19350)
+    // work around inotify issue (file is unwatched when replaced with other file)
     if (mpConfigurationFileWatch->files().isEmpty() && !mConfigurationFile.isEmpty())
-        mpConfigurationFileWatch->addPath(mConfigurationFile);
+        QTimer::singleShot(100, this, &ConfiguratorHelper::doReadConfigurationFile);
     if (!mpConfigureFunc)
         return;
     mpConfigureFunc(rFileName);
     emit configurationFileChanged(rFileName, mConfigureError.count() > 0);
+}
+
+void ConfiguratorHelper::doReadConfigurationFile()
+{
+    if (mpConfigurationFileWatch->files().isEmpty() && !mConfigurationFile.isEmpty())
+        mpConfigurationFileWatch->addPath(mConfigurationFile);
 }
 
 void ConfiguratorHelper::doSetConfigurationFile(const QString &rFileName,

--- a/src/log4qt/helpers/configuratorhelper.cpp
+++ b/src/log4qt/helpers/configuratorhelper.cpp
@@ -53,6 +53,9 @@ LOG4QT_IMPLEMENT_INSTANCE(ConfiguratorHelper)
 
 void ConfiguratorHelper::doConfigurationFileChanged(const QString &rFileName)
 {
+    // work around a bug in the inotify qfsw implementation (Qt bug 19350)
+    if (mpConfigurationFileWatch->files().isEmpty() && !mConfigurationFile.isEmpty())
+        mpConfigurationFileWatch->addPath(mConfigurationFile);
     if (!mpConfigureFunc)
         return;
     mpConfigureFunc(rFileName);

--- a/src/log4qt/helpers/configuratorhelper.h
+++ b/src/log4qt/helpers/configuratorhelper.h
@@ -128,6 +128,7 @@ signals:
 
 private slots:
     void doConfigurationFileChanged(const QString &rFileName);
+    void doReadConfigurationFile();
 
 private:
     void doSetConfigurationFile(const QString &rFileName,


### PR DESCRIPTION
The inotify implementation of QFileSystemWatcher seems to have a bug when the watched file is replaced by another one. For example kate does save the current content in a temporary file and then renames it. After this operation, QFileSystemWatcher/INotify does no longer watch this file.
This leads to the problem that one can only modify the property file once without restarting the application :(