### PR TITLE
Apply clang-tidy with modernize-use-nullptr,modernize-use-override

### DIFF
--- a/src/log4qt/appenderskeleton.cpp
+++ b/src/log4qt/appenderskeleton.cpp
@@ -52,7 +52,7 @@ private:
 
 inline RecursionGuardLocker::RecursionGuardLocker(bool *pGuard)
 {
-    Q_ASSERT_X(pGuard != 0, "RecursionGuardLocker::RecursionGuardLocker()", "Pointer to guard bool must not be null");
+    Q_ASSERT_X(pGuard != nullptr, "RecursionGuardLocker::RecursionGuardLocker()", "Pointer to guard bool must not be null");
 
     mpGuard = pGuard;
     *mpGuard = true;

--- a/src/log4qt/asyncappender.cpp
+++ b/src/log4qt/asyncappender.cpp
@@ -70,9 +70,9 @@ void AsyncAppender::close()
         mpThread->quit();
         mpThread->wait();
         delete mpThread;
-        mpThread = 0;
+        mpThread = nullptr;
         delete mpDispatcher;
-        mpDispatcher = 0;
+        mpDispatcher = nullptr;
     }
 }
 

--- a/src/log4qt/binaryfileappender.cpp
+++ b/src/log4qt/binaryfileappender.cpp
@@ -20,8 +20,8 @@ BinaryFileAppender::BinaryFileAppender(QObject *pParent) :
     mAppendFile(false),
     mBufferedIo(true),
     mFileName(),
-    mpFile(0),
-    mpDataStream(0),
+    mpFile(nullptr),
+    mpDataStream(nullptr),
     mByteOrder(QDataStream::LittleEndian),
     mFloatingPointPrecision(QDataStream::DoublePrecision),
     mStreamVersion(QDataStream::Qt_5_3)
@@ -33,8 +33,8 @@ BinaryFileAppender::BinaryFileAppender(const QString &rFileName, QObject *pParen
     mAppendFile(false),
     mBufferedIo(true),
     mFileName(rFileName),
-    mpFile(0),
-    mpDataStream(0),
+    mpFile(nullptr),
+    mpDataStream(nullptr),
     mByteOrder(QDataStream::LittleEndian),
     mFloatingPointPrecision(QDataStream::DoublePrecision),
     mStreamVersion(QDataStream::Qt_5_3)
@@ -46,8 +46,8 @@ BinaryFileAppender::BinaryFileAppender(const QString &rFileName, bool append, QO
     mAppendFile(append),
     mBufferedIo(true),
     mFileName(rFileName),
-    mpFile(0),
-    mpDataStream(0),
+    mpFile(nullptr),
+    mpDataStream(nullptr),
     mByteOrder(QDataStream::LittleEndian),
     mFloatingPointPrecision(QDataStream::DoublePrecision),
     mStreamVersion(QDataStream::Qt_5_3)
@@ -59,8 +59,8 @@ BinaryFileAppender::BinaryFileAppender(const QString &rFileName, bool append, bo
     mAppendFile(append),
     mBufferedIo(buffered),
     mFileName(rFileName),
-    mpFile(0),
-    mpDataStream(0),
+    mpFile(nullptr),
+    mpDataStream(nullptr),
     mByteOrder(QDataStream::LittleEndian),
     mFloatingPointPrecision(QDataStream::DoublePrecision),
     mStreamVersion(QDataStream::Qt_5_3)
@@ -120,11 +120,11 @@ void BinaryFileAppender::closeFile()
     if (mpFile)
         logger()->debug("Closing file '%1' for appender '%2'", mpFile->fileName(), name());
 
-    setWriter(0);
+    setWriter(nullptr);
     delete mpDataStream;
-    mpDataStream = 0;
+    mpDataStream = nullptr;
     delete mpFile;
-    mpFile = 0;
+    mpFile = nullptr;
 }
 
 bool BinaryFileAppender::handleIoErrors() const
@@ -150,7 +150,7 @@ void BinaryFileAppender::createDataStream()
 
 void BinaryFileAppender::openFile()
 {
-    Q_ASSERT_X(mpFile == 0 && mpDataStream == 0, "BinaryFileAppender::openFile()", "Opening file without closing previous file");
+    Q_ASSERT_X(mpFile == nullptr && mpDataStream == nullptr, "BinaryFileAppender::openFile()", "Opening file without closing previous file");
 
     QFileInfo file_info(mFileName);
     QDir parent_dir = file_info.dir();

--- a/src/log4qt/binarywriterappender.cpp
+++ b/src/log4qt/binarywriterappender.cpp
@@ -8,7 +8,7 @@ namespace Log4Qt
 
 BinaryWriterAppender::BinaryWriterAppender(QObject *pParent) :
     AppenderSkeleton(false, pParent),
-    mpWriter(0)
+    mpWriter(nullptr)
 {
 }
 
@@ -114,7 +114,7 @@ void BinaryWriterAppender::closeWriter()
         return;
 
     writeFooter();
-    mpWriter = 0;
+    mpWriter = nullptr;
 }
 
 bool BinaryWriterAppender::handleIoErrors() const

--- a/src/log4qt/fileappender.cpp
+++ b/src/log4qt/fileappender.cpp
@@ -152,9 +152,9 @@ void FileAppender::closeFile()
 
     setWriter(nullptr);
     delete mpTextStream;
-    mpTextStream = 0;
+    mpTextStream = nullptr;
     delete mpFile;
-    mpFile = 0;
+    mpFile = nullptr;
 }
 
 bool FileAppender::handleIoErrors() const
@@ -173,7 +173,7 @@ bool FileAppender::handleIoErrors() const
 
 void FileAppender::openFile()
 {
-    Q_ASSERT_X(mpFile == 0 && mpTextStream == 0, "FileAppender::openFile()", "Opening file without closing previous file");
+    Q_ASSERT_X(mpFile == nullptr && mpTextStream == nullptr, "FileAppender::openFile()", "Opening file without closing previous file");
 
     QFileInfo file_info(mFileName);
     QDir parent_dir = file_info.dir();

--- a/src/log4qt/helpers/binaryclasslogger.cpp
+++ b/src/log4qt/helpers/binaryclasslogger.cpp
@@ -9,7 +9,7 @@ namespace Log4Qt
 {
 
 BinaryClassLogger::BinaryClassLogger()
-    : mpLogger(0)
+    : mpLogger(nullptr)
 {
 }
 
@@ -19,7 +19,7 @@ BinaryLogger *BinaryClassLogger::logger(const QObject *pObject)
     QString loggerName(pObject->metaObject()->className());
     loggerName += QStringLiteral("@@binary@@");
     if (!mpLogger.loadAcquire())
-        mpLogger.testAndSetOrdered(0, qobject_cast<BinaryLogger *>(LogManager::logger(loggerName)));
+        mpLogger.testAndSetOrdered(nullptr, qobject_cast<BinaryLogger *>(LogManager::logger(loggerName)));
     return mpLogger.loadAcquire();
 }
 

--- a/src/log4qt/helpers/classlogger.cpp
+++ b/src/log4qt/helpers/classlogger.cpp
@@ -42,7 +42,7 @@ Logger *ClassLogger::logger(const QObject *pObject)
 {
     Q_ASSERT_X(pObject, "ClassLogger::logger()", "pObject must not be null");
     if (!static_cast<Logger *>(mpLogger.loadAcquire()))
-        mpLogger.testAndSetOrdered(0,
+        mpLogger.testAndSetOrdered(nullptr,
                                    LogManager::logger(QLatin1String(pObject->metaObject()->className())));
     return const_cast<Logger *>(static_cast<Logger *>(mpLogger.loadAcquire()));
 }

--- a/src/log4qt/helpers/logerror.cpp
+++ b/src/log4qt/helpers/logerror.cpp
@@ -98,7 +98,7 @@ LogError::LogError(const char *pMessage,
 
 QString LogError::translatedMessage() const
 {
-    return QCoreApplication::translate(mContext.toLatin1().constData(), mMessage.toUtf8().constData(), 0);
+    return QCoreApplication::translate(mContext.toLatin1().constData(), mMessage.toUtf8().constData(), nullptr);
 }
 
 LogError LogError::lastError()

--- a/src/log4qt/helpers/patternformatter.cpp
+++ b/src/log4qt/helpers/patternformatter.cpp
@@ -139,7 +139,7 @@ private:
     Q_DISABLE_COPY(BasicPatternConverter)
 
 protected:
-    virtual QString convert(const LoggingEvent &rLoggingEvent) const override;
+    QString convert(const LoggingEvent &rLoggingEvent) const override;
 
 private:
     Type mType;
@@ -170,7 +170,7 @@ private:
     Q_DISABLE_COPY(DatePatternConverter)
 
 protected:
-    virtual QString convert(const LoggingEvent &rLoggingEvent) const override;
+    QString convert(const LoggingEvent &rLoggingEvent) const override;
 
 private:
     QString mFormat;
@@ -199,7 +199,7 @@ private:
     Q_DISABLE_COPY(LiteralPatternConverter)
 
 protected:
-    virtual QString convert(const LoggingEvent &rLoggingEvent) const override;
+    QString convert(const LoggingEvent &rLoggingEvent) const override;
 
 private:
     QString mLiteral;
@@ -230,7 +230,7 @@ private:
     Q_DISABLE_COPY(LoggerPatternConverter)
 
 protected:
-    virtual QString convert(const LoggingEvent &rLoggingEvent) const override;
+    QString convert(const LoggingEvent &rLoggingEvent) const override;
 
 private:
     int mPrecision;
@@ -262,7 +262,7 @@ private:
     Q_DISABLE_COPY(MDCPatternConverter)
 
 protected:
-    virtual QString convert(const LoggingEvent &rLoggingEvent) const override;
+    QString convert(const LoggingEvent &rLoggingEvent) const override;
 
 private:
     QString mKey;

--- a/src/log4qt/hierarchy.cpp
+++ b/src/log4qt/hierarchy.cpp
@@ -132,13 +132,13 @@ Logger *Hierarchy::createLogger(const QString &orgName)
 
     const QString name_separator = QLatin1String("::");
 
-    Logger *p_logger = mLoggers.value(rName, 0);
+    Logger *p_logger = mLoggers.value(rName, nullptr);
     if (p_logger != nullptr)
         return p_logger;
 
     if (rName.isEmpty())
     {
-        p_logger = new Logger(this, Level::DEBUG_INT, QLatin1String("root"), 0);
+        p_logger = new Logger(this, Level::DEBUG_INT, QLatin1String("root"), nullptr);
         mLoggers.insert(QString(), p_logger);
         return p_logger;
     }

--- a/src/log4qt/loggingevent.cpp
+++ b/src/log4qt/loggingevent.cpp
@@ -306,7 +306,7 @@ QDataStream &operator>>(QDataStream &rStream, LoggingEvent &rLoggingEvent)
            >> rLoggingEvent.mThreadName
            >> rLoggingEvent.mTimeStamp;
     if (logger.isEmpty())
-        rLoggingEvent.mpLogger = 0;
+        rLoggingEvent.mpLogger = nullptr;
     else
         rLoggingEvent.mpLogger = Logger::logger(logger);
 

--- a/src/log4qt/logmanager.cpp
+++ b/src/log4qt/logmanager.cpp
@@ -513,6 +513,6 @@ static bool isFatal(QtMsgType msgType)
     return false;
 }
 
-LogManager *LogManager::mspInstance = 0;
+LogManager *LogManager::mspInstance = nullptr;
 
 }  // namespace Log4Qt

--- a/src/log4qt/systemlogappender.cpp
+++ b/src/log4qt/systemlogappender.cpp
@@ -69,7 +69,7 @@ static QString encodeName(const QString &name, bool allowUpper = false)
 namespace Log4Qt
 {
 SystemLogAppender::SystemLogAppender(QObject *parent) :
-    AppenderSkeleton(parent), ident(0)
+    AppenderSkeleton(parent), ident(nullptr)
 {
     setServiceName(QCoreApplication::applicationName());
 }

--- a/src/log4qt/telnetappender.cpp
+++ b/src/log4qt/telnetappender.cpp
@@ -163,7 +163,7 @@ void TelnetAppender::closeServer()
     mTcpSockets.clear();
 
     delete mpTcpServer;
-    mpTcpServer = 0;
+    mpTcpServer = nullptr;
 }
 
 QList<QTcpSocket *> TelnetAppender::clients() const

--- a/src/log4qt/writerappender.cpp
+++ b/src/log4qt/writerappender.cpp
@@ -175,7 +175,7 @@ void WriterAppender::closeWriter()
         return;
 
     writeFooter();
-    mpWriter = 0;
+    mpWriter = nullptr;
 }
 
 bool WriterAppender::handleIoErrors() const


### PR DESCRIPTION
Since this project is using c++11, we should also use nullptr and override everywhere
Converted with clang-tidy
- https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-nullptr.html
- https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html