### PR TITLE
Rollingfileappender: Roll file on startup if appendFile is false

### DIFF
--- a/src/log4qt/fileappender.h
+++ b/src/log4qt/fileappender.h
@@ -133,7 +133,7 @@ protected:
      * If the parent directory of the specified file does not exists,
      * it is created.
      */
-    void openFile();
+    virtual void openFile();
 
     /*!
      * Removes the file \a rFile. If the operation is successful, true is

--- a/src/log4qt/rollingfileappender.h
+++ b/src/log4qt/rollingfileappender.h
@@ -33,6 +33,8 @@ namespace Log4Qt
 /*!
  * \brief The class RollingFileAppender extends FileAppender to backup
  *        the log files when they reach a certain size.
+ *        On application restart the existing log files are rolled
+ *        if appendFile is set to false to avoid data loss.
  *
  * \note All the functions declared in this class are thread-safe.
  *
@@ -91,6 +93,7 @@ public:
 
 protected:
     virtual void append(const LoggingEvent &rEvent) override;
+    virtual void openFile() override;
 
 private:
     void rollOver();


### PR DESCRIPTION
When appendFile is set to false (which is the default), the RollingFileAppender did not roll the current log file which results in an unexpected logdata loss. 