### PR TITLE
Qt 5.10 print a warning when an empty filename is passed to QFile::ex…

### DIFF
--- a/src/log4qt/logmanager.cpp
+++ b/src/log4qt/logmanager.cpp
@@ -289,7 +289,7 @@ void LogManager::doStartup()
 
     // Configuration using setting Configuration
     value = InitialisationHelper::setting(QLatin1String("Configuration"));
-    if (QFile::exists(value))
+    if (!value.isEmpty() && QFile::exists(value))
     {
         static_logger()->debug("Default initialisation configures from file '%1' specified by Configure", value);
         PropertyConfigurator::configure(value);


### PR DESCRIPTION
…its() (and others) - avoid it by checking if value is empty