### PR TITLE
ConfiguratorHelper: make sure to not pass empty filename to QFileInfo::exists()

### DIFF
--- a/src/log4qt/helpers/configuratorhelper.cpp
+++ b/src/log4qt/helpers/configuratorhelper.cpp
@@ -79,7 +79,8 @@ void ConfiguratorHelper::doSetConfigurationFile(const QString &rFileName,
     mConfigurationFile.setFile(rFileName);
     mpConfigureFunc = nullptr;
     delete mpConfigurationFileWatch;
-    if (!QFileInfo::exists(rFileName))
+    mpConfigurationFileWatch = nullptr;
+    if (rFileName.isEmpty() || !QFileInfo::exists(rFileName))
         return;
 
     mpConfigureFunc = pConfigureFunc;


### PR DESCRIPTION
To avoid a Qt warning message.
Also make sure to properly reset mpConfigurationFileWatch after deleting