### PR TITLE
TTCCLayout(QString dateFormat) crash fix

### DIFF
--- a/src/log4qt/ttcclayout.cpp
+++ b/src/log4qt/ttcclayout.cpp
@@ -44,9 +44,9 @@ TTCCLayout::TTCCLayout(const QString &dateFormat,
     Layout(parent),
     mCategoryPrefixing(true),
     mContextPrinting(true),
-    mDateFormat(dateFormat),
     mThreadPrinting(true)
 {
+    setDateFormat(dateFormat);
 }
 
 TTCCLayout::TTCCLayout(DateFormat dateFormat,


### PR DESCRIPTION
calling "auto *layout = new Log4Qt::TTCCLayout("dd.MM.yy");" crash caused. This will fix it.