### PR TITLE
Add support for the property "encoding" in the configuration file

### DIFF
--- a/src/log4qt/helpers/factory.cpp
+++ b/src/log4qt/helpers/factory.cpp
@@ -363,6 +363,13 @@ void Factory::doSetObjectProperty(QObject *object,
         variant = QVariant::fromValue(OptionConverter::toLevel(value, &ok));
     else if (type == QStringLiteral("QString"))
         variant = value;
+#if QT_VERSION < 0x060000
+    else if (type == QStringLiteral("QTextCodec*"))
+        variant = QVariant::fromValue(OptionConverter::toEncoding(value, &ok));
+#else
+    else if (type == QStringLiteral("QStringConverter::Encoding"))
+        variant = QVariant::fromValue(OptionConverter::toEncoding(value, &ok));
+#endif
     else
     {
         LogError e = LOG4QT_ERROR(QT_TR_NOOP("Cannot convert to type '%1' for property '%2' on object of class '%3'"),

--- a/src/log4qt/helpers/optionconverter.cpp
+++ b/src/log4qt/helpers/optionconverter.cpp
@@ -247,4 +247,43 @@ int OptionConverter::toTarget(const QString &option,
     return ConsoleAppender::STDOUT_TARGET;
 }
 
+#if QT_VERSION < 0x060000
+QTextCodec* OptionConverter::toEncoding(const QString &option,
+                              bool *ok)
+{
+    QTextCodec* encoding = QTextCodec::codecForName(option.toUtf8());
+    if (encoding) {
+        *ok = true;
+        return encoding;
+    }
+
+    *ok = false;
+
+    LogError e = LOG4QT_ERROR(QT_TR_NOOP("Invalid option string '%1' for a QTextCodec"),
+                              CONFIGURATOR_INVALID_OPTION_ERROR,
+                              "Log4Qt::OptionConverter");
+    e << option;
+    logger()->error(e);
+    return 0;
+}
+#else
+    QStringConverter::Encoding OptionConverter::toEncoding(const QString &option,
+                                            bool *ok)
+    {
+        std::optional<QStringConverter::Encoding> encoding = QStringConverter::encodingForName(option.toStdString().c_str());
+        if (encoding.has_value()) {
+            *ok = true;
+            return encoding.value();
+        }
+
+        *ok = false;
+
+        LogError e = LOG4QT_ERROR(QT_TR_NOOP("Invalid option string '%1' for a QStringConverter::Encoding"),
+                                  CONFIGURATOR_INVALID_OPTION_ERROR,
+                                  "Log4Qt::OptionConverter");
+        e << option;
+        logger()->error(e);
+        return QStringConverter::System;
+    }
+#endif
 } // namespace Log4Qt

--- a/src/log4qt/helpers/optionconverter.h
+++ b/src/log4qt/helpers/optionconverter.h
@@ -26,6 +26,13 @@
 
 #include <QString>
 
+#if QT_VERSION >= 0x060000
+#include <QStringConverter>
+#else
+#include <QTextCodec>
+Q_DECLARE_METATYPE(QTextCodec*)
+#endif
+
 namespace Log4Qt
 {
 class Properties;
@@ -109,6 +116,28 @@ public:
      */
     static int toTarget(const QString &option,
                         bool *ok = nullptr);
+
+#if QT_VERSION < 0x060000
+    /*!
+     * Converts the option \a option to a QTextCodec* value using
+     * QTextCodec::codecForName(). If the conversion is successful,
+     * the codec is returned and \a ok is set to true. Otherwise an
+     * error is written to the log, \a ok is set to false and
+     * 0 is returned.
+     */
+    static QTextCodec* toEncoding(const QString &option,
+                                  bool *ok = nullptr);
+#else
+    /*!
+     * Converts the option \a option to a QStringConverter::Encoding value using
+     * QStringConverter::encodingForName(). If the conversion is successful,
+     * the codec is returned and \a ok is set to true. Otherwise an
+     * error is written to the log, \a ok is set to false and
+     * QStringConverter::System is returned.
+     */
+    static QStringConverter::Encoding toEncoding(const QString &option,
+                                  bool *ok = nullptr);
+#endif
 };
 
 } // namespace Log4Qt


### PR DESCRIPTION
I found that log4qt currently does not support the `encoding` property in the configuration file, for example, `log4j.appender.rollingFile.encoding=UTF-8`, and `log4j.appender.console.encoding=UTF-8`, etc.

So, this PR adds support for these properties.