### PR TITLE
fix the log file path error when using system environment variables in log.conf

### DIFF
--- a/src/log4qt/binaryfileappender.cpp
+++ b/src/log4qt/binaryfileappender.cpp
@@ -92,6 +92,20 @@ BinaryFileAppender::~BinaryFileAppender()
     closeInternal();
 }
 
+void BinaryFileAppender::setFile(const QString &fileName)
+{
+    QMutexLocker locker(&mObjectGuard);
+    mFileName = fileName;
+
+#ifdef Q_OS_WIN
+    // Let windows resolve any environment variables included in the file path
+    wchar_t buffer[MAX_PATH];
+    if (ExpandEnvironmentStringsW(mFileName.toStdWString().c_str(), buffer, MAX_PATH))
+        mFileName = QString::fromWCharArray(buffer);
+#endif
+
+}
+
 void BinaryFileAppender::activateOptions()
 {
     QMutexLocker locker(&mObjectGuard);
@@ -186,13 +200,6 @@ void BinaryFileAppender::openFile()
         parent_dir.cdUp();
         parent_dir.mkdir(name);
     }
-
-#ifdef Q_OS_WIN
-    // Let windows resolve any environment variables included in the file path
-    wchar_t buffer[MAX_PATH];
-    if (ExpandEnvironmentStringsW(mFileName.toStdWString().c_str(), buffer, MAX_PATH))
-        mFileName = QString::fromWCharArray(buffer);
-#endif
 
     mFile = new QFile(mFileName);
     QFile::OpenMode mode = QIODevice::WriteOnly | QIODevice::Text;

--- a/src/log4qt/binaryfileappender.h
+++ b/src/log4qt/binaryfileappender.h
@@ -122,11 +122,6 @@ inline void BinaryFileAppender::setBufferedIo(bool buffered)
     mBufferedIo = buffered;
 }
 
-inline void BinaryFileAppender::setFile(const QString &fileName)
-{
-    QMutexLocker locker(&mObjectGuard);
-    mFileName = fileName;
-}
 
 inline QDataStream::ByteOrder BinaryFileAppender::byteOrder() const
 {

--- a/src/log4qt/fileappender.h
+++ b/src/log4qt/fileappender.h
@@ -182,11 +182,6 @@ inline void FileAppender::setBufferedIo(bool buffered)
     mBufferedIo = buffered;
 }
 
-inline void FileAppender::setFile(const QString &fileName)
-{
-    QMutexLocker locker(&mObjectGuard);
-    mFileName = fileName;
-}
 
 
 } // namespace Log4Qt

--- a/src/log4qt/mainthreadappender.h
+++ b/src/log4qt/mainthreadappender.h
@@ -43,6 +43,7 @@ class LOG4QT_EXPORT MainThreadAppender : public AppenderSkeleton, public Appende
 
 public:
     MainThreadAppender(QObject *parent = nullptr);
+    ~MainThreadAppender(){;}
 
     bool requiresLayout() const override;
 

--- a/src/log4qt/mainthreadappender.h
+++ b/src/log4qt/mainthreadappender.h
@@ -43,7 +43,6 @@ class LOG4QT_EXPORT MainThreadAppender : public AppenderSkeleton, public Appende
 
 public:
     MainThreadAppender(QObject *parent = nullptr);
-    ~MainThreadAppender(){;}
 
     bool requiresLayout() const override;
 


### PR DESCRIPTION
system : ubuntu20
compiler :  x86_64-linux-gnu g++ 
compiler version : 9.4.0
build error : undefined reference to 'Log4Qt::AppenderAttachable::~AppenderAttachable()'